### PR TITLE
add more 5 tests accept condition to fit CAB230 Assignment 3.docx

### DIFF
--- a/integration.test.js
+++ b/integration.test.js
@@ -1292,10 +1292,11 @@ describe("profile", () => {
           expect(response.data.error).toBe(true));
         test("should contain message property", () =>
           expect(response.data).toHaveProperty("message"));
-        test("should return specific message for 'Request body incomplete: firstName, lastName, dob and address are required.'", () =>
-          expect(response.data.message).toBe(
-            "Request body incomplete: firstName, lastName, dob and address are required."
-          ));
+        test("should return specific message for 'Request body incomplete: firstName, lastName, dob and address are required.' (optional last period)", () =>
+          expect([
+            "Request body incomplete: firstName, lastName, dob and address are required.",
+            "Request body incomplete: firstName, lastName, dob and address are required",
+          ]).toContain(response.data.message));
       });
 
       describe("with invalid firstName", () => {
@@ -1328,10 +1329,11 @@ describe("profile", () => {
           expect(response.data.error).toBe(true));
         test("should contain message property", () =>
           expect(response.data).toHaveProperty("message"));
-        test("should return a specific message for 'Request body invalid: firstName, lastName and address must be strings only.'", () =>
-          expect(response.data.message).toBe(
-            "Request body invalid: firstName, lastName and address must be strings only."
-          ));
+        test("should return a specific message for 'Request body invalid: firstName, lastName(, dob) and address must be strings only.'", () =>
+          expect([
+            "Request body invalid: firstName, lastName, dob and address must be strings only",
+            "Request body invalid: firstName, lastName and address must be strings only.",
+          ]).toContain(response.data.message));
       });
 
       describe("with invalid lastName", () => {
@@ -1436,10 +1438,11 @@ describe("profile", () => {
           expect(response.data.error).toBe(true));
         test("should contain message property", () =>
           expect(response.data).toHaveProperty("message"));
-        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.'", () =>
-          expect(response.data.message).toBe(
-            "Invalid input: dob must be a real date in format YYYY-MM-DD."
-          ));
+        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.' (optional last period)", () =>
+          expect([
+            "Invalid input: dob must be a real date in format YYYY-MM-DD.",
+            "Invalid input: dob must be a real date in format YYYY-MM-DD",
+          ]).toContain(response.data.message));
       });
 
       describe("with valid formatted non-real date (out of bounds check)", () => {
@@ -1472,10 +1475,11 @@ describe("profile", () => {
           expect(response.data.error).toBe(true));
         test("should contain message property", () =>
           expect(response.data).toHaveProperty("message"));
-        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.'", () =>
-          expect(response.data.message).toBe(
-            "Invalid input: dob must be a real date in format YYYY-MM-DD."
-          ));
+        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.' (optional last period)", () =>
+          expect([
+            "Invalid input: dob must be a real date in format YYYY-MM-DD.",
+            "Invalid input: dob must be a real date in format YYYY-MM-DD",
+          ]).toContain(response.data.message));
       });
 
       describe("with valid formatted non-real date (JavaScript date rollover check)", () => {
@@ -1508,10 +1512,11 @@ describe("profile", () => {
           expect(response.data.error).toBe(true));
         test("should contain message property", () =>
           expect(response.data).toHaveProperty("message"));
-        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.'", () =>
-          expect(response.data.message).toBe(
-            "Invalid input: dob must be a real date in format YYYY-MM-DD."
-          ));
+        test("should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.' (optional last period)", () =>
+          expect([
+            "Invalid input: dob must be a real date in format YYYY-MM-DD.",
+            "Invalid input: dob must be a real date in format YYYY-MM-DD",
+          ]).toContain(response.data.message));
       });
 
       describe("with valid formatted non-real date (non leap-year check)", () => {


### PR DESCRIPTION
## Modified tests

- should return specific message for 'Request body incomplete: firstName, lastName, dob and address are required.' (optional last period)
- should return a specific message for 'Request body invalid: firstName, lastName(, dob) and address must be strings only.
- should return a specific message for 'Invalid input: dob must be a real date in format YYYY-MM-DD.' (optional last period)

## References taken from CAB230 Assignment 3.docx

<img width="1502" alt="image" src="https://github.com/chadggay/movieapi-tests/assets/10560038/4cf59513-9c76-4e3e-ab27-a1cfebc7b2e1">
<img width="1500" alt="image" src="https://github.com/chadggay/movieapi-tests/assets/10560038/ce3d7186-fe36-40d6-8b9d-f50acdfdc271">
<img width="1503" alt="image" src="https://github.com/chadggay/movieapi-tests/assets/10560038/e1622cd5-1903-46ff-894f-b7547937c5c4">
